### PR TITLE
Move login form to separate model

### DIFF
--- a/app/views/application/_email_login.html.haml
+++ b/app/views/application/_email_login.html.haml
@@ -1,0 +1,20 @@
+.modal-dialog
+  .modal-content
+    .modal-header
+      %button.close{:type => 'button', 'data-dismiss' => 'modal'}
+        &times;
+      %h4.modal-title Log in with Email
+    .modal-body
+      - flash.each do |name, msg|
+        - if name == :alert
+          %div{class: 'alert alert-warning'}
+            %div= msg
+      = simple_form_for(:user, url: user_session_path) do |f|
+        = f.input :email, required: false, autofocus: true, label: false, placeholder: 'Email', input_html: { class: 'input-lg' }
+        = f.input :password, required: false, label: false, placeholder: 'Password', input_html: { class: 'input-lg' }
+        .pull-right
+          = link_to "Forgot your password?", new_password_path(:user)
+        = f.input :remember_me, as: :boolean, label: false, inline_label: true
+        = f.button :submit, "Log in", data: { disable_with: 'Log in' }, class: 'btn btn-block btn-lg btn-primary', id: 'log-in-btn'
+      Don't have an account?
+      %a{:href => '', 'data-dismiss' => 'modal', 'data-target' => '#registration-modal', 'data-toggle' => 'modal'} Create one now

--- a/app/views/application/_login.html.haml
+++ b/app/views/application/_login.html.haml
@@ -11,14 +11,3 @@
             %div= msg
 
       = render 'social_login_buttons'
-      %hr
-      %h5 Log in with email
-      = simple_form_for(:user, url: user_session_path) do |f|
-        = f.input :email, required: false, autofocus: true, label: false, placeholder: 'Email', input_html: { class: 'input-lg' }
-        = f.input :password, required: false, label: false, placeholder: 'Password', input_html: { class: 'input-lg' }
-        .pull-right
-          = link_to "Forgot your password?", new_password_path(:user)
-        = f.input :remember_me, as: :boolean, label: false, inline_label: true
-        = f.button :submit, "Log in", data: { disable_with: 'Log in' }, class: 'btn btn-block btn-lg btn-primary', id: 'log-in-btn'
-      Don't have an account?
-      %a{:href => '', 'data-dismiss' => 'modal', 'data-target' => '#registration-modal', 'data-toggle' => 'modal'} Create one now

--- a/app/views/application/_registration.html.haml
+++ b/app/views/application/_registration.html.haml
@@ -5,9 +5,6 @@
         x
       %h4.modal-title= create_account_title
     .modal-body
-      = render 'social_login_buttons'
-      %hr
-      %h5 Or create an account
       = simple_form_for(resource, as: :user, url: registration_path(:user)) do |f|
         = f.error_notification
         = f.input :name, required: true, autofocus: true

--- a/app/views/application/_social_login_buttons.html.haml
+++ b/app/views/application/_social_login_buttons.html.haml
@@ -1,9 +1,12 @@
 = link_to user_omniauth_authorize_path(:facebook), class: 'btn btn-primary btn-facebook btn-lg btn-block login-social-btn' do
-  %span.fa.fa-facebook.login-social-icon
+  %span.fa.fa-facebook.login-social-icon.fa-fw
   Log in with Facebook
 = link_to user_omniauth_authorize_path(:twitter), class: 'btn btn-info btn-lg btn-block login-social-btn' do
-  %span.fa.fa-twitter.login-social-icon
+  %span.fa.fa-twitter.login-social-icon.fa-fw
   Log in with Twitter
 = link_to user_omniauth_authorize_path(:google_oauth2), class: 'btn btn-danger btn-lg btn-block login-social-btn' do
-  %span.fa.fa-google.login-social-icon
+  %span.fa.fa-google.login-social-icon.fa-fw
   Log in with Google
+= link_to '', class: 'btn btn-grey btn-lg btn-block login-social-btn', 'data-dismiss' => 'modal', 'data-target' => '#email-login-modal', 'data-toggle' => 'modal' do
+  %span.fa.fa-envelope.login-social-icon.fa-fw
+  Log in with Email

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -14,6 +14,8 @@
         = render 'login'
       #registration-modal.modal.fade
         = render 'registration'
+      #email-login-modal.modal.fade
+        = render 'email_login'
     = render 'footer'
 
     :javascript

--- a/app/views/layouts/embedded.html.haml
+++ b/app/views/layouts/embedded.html.haml
@@ -27,4 +27,3 @@
 
       ga('create', 'UA-44134501-1', 'askaway.co.nz');
       ga('send', 'pageview');
-

--- a/features/step_definitions/shared_steps.rb
+++ b/features/step_definitions/shared_steps.rb
@@ -5,6 +5,7 @@ Given(/^I am logged in$/) do
   @is_admin ||= false
   @user = User.create!(name: @name, email: @email, password: password, is_admin: @is_admin)
   visit new_user_session_path
+  click_on 'Log in with Email'
   find('.simple_form.user').fill_in 'user_email', with: @email
   find('.simple_form.user').fill_in 'user_password', with: password
   click_on 'log-in-btn'


### PR DESCRIPTION
- Move login form to it's own modal
- Add 'Log in with Email' button to login stack
- Remove login stack from top of sign up modal
- Fix icon width on login buttons
