### PR TITLE
Prevent answer toggling when text is selected.

### DIFF
--- a/app/assets/javascripts/controllers/questions.js
+++ b/app/assets/javascripts/controllers/questions.js
@@ -9,7 +9,7 @@ askaway.controller('QuestionsCtrl', ['$scope', '$http', function( $scope, $http 
     var $target = $(e.target),
       $veto = $target.closest('a[href], form');
 
-    if (window.getSelection().toString() != '') return;
+    if (window.getSelection && window.getSelection().toString() != '') return;
 
     if ($veto.length === 0) {
       this.question.expanded = !this.question.expanded;


### PR DESCRIPTION
Seems to do the trick in "modern" browsers, will still toggle regardless in IE8 :violin: 
