### PR TITLE
Add Profanity Filter to Comments

### DIFF
--- a/app/admin/comment.rb
+++ b/app/admin/comment.rb
@@ -1,11 +1,15 @@
 ActiveAdmin.register Comment do
   permit_params :body, :question_id, :user_id
 
+  scope :all
+  scope :awaiting_review
+
   form do |f|
     f.inputs do
       f.input :question, collection: Question.all.map{|q| [q.body, q.id]}
       f.input :user
       f.input :body
+      f.input :workflow_state, as: :select, collection: Comment.workflow_spec.states.keys
     end
     f.actions
   end

--- a/app/concerns/profanity_filter.rb
+++ b/app/concerns/profanity_filter.rb
@@ -18,6 +18,8 @@ module ProfanityFilter
 
     scope :visible_to_public, -> { where("workflow_state IN ('default', 'accepted')") }
     scope :awaiting_review, -> { with_awaiting_review_state }
+
+    before_create :check_for_obscenity
   end
 
   private

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -7,7 +7,11 @@ class CommentsController < ApplicationController
     @comment.user = current_user
     authorize @comment
     if @comment.save
-      flash[:notice] = 'Comment posted.'
+      if @comment.awaiting_review?
+        flash[:notice] = 'Thanks! Your comment will be reviewed'
+      else
+        flash[:notice] = 'Comment posted.'
+      end
       redirect_to @question
     else
       render template: "questions/show"

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -36,7 +36,7 @@ class QuestionsController < ApplicationController
     authorize @question
     redirect_to_canonical_show_path(@question) unless request.xhr?
     @comment = Comment.new
-    @comments = @question.comments.order(created_at: :asc)
+    @comments = @question.comments.visible_to_public.order(created_at: :asc)
     if show_answer_form?
       @new_answer = Answer.new
     end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -11,6 +11,8 @@
 #
 
 class Comment < ActiveRecord::Base
+  include ProfanityFilter
+
   belongs_to :question, touch: true, counter_cache: true
   belongs_to :user
   validates :body, presence: true

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -41,8 +41,6 @@ class Question < ActiveRecord::Base
   validates_length_of :body, maximum: BODY_MAX_LENGTH
   validates_numericality_of :votes_count, greater_than_or_equal_to: 0
 
-  before_create :check_for_obscenity
-
   scope :answered, -> { joins(:answers).order('questions.answers_count DESC') }
   scope :unanswered, -> { where('questions.answers_count < 4') }
   scope :trending, -> { order('ranking(questions.created_at, questions.votes_count, questions.answers_count) DESC') }

--- a/db/migrate/20140826095352_add_workflow_state_to_comment.rb
+++ b/db/migrate/20140826095352_add_workflow_state_to_comment.rb
@@ -1,0 +1,6 @@
+class AddWorkflowStateToComment < ActiveRecord::Migration
+  def change
+    add_column :comments, :workflow_state, :string, default: 'default'
+    add_index :comments, :workflow_state
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -120,7 +120,8 @@ CREATE TABLE comments (
     user_id integer,
     body text,
     created_at timestamp without time zone,
-    updated_at timestamp without time zone
+    updated_at timestamp without time zone,
+    workflow_state character varying(255) DEFAULT 'default'::character varying
 );
 
 
@@ -953,6 +954,13 @@ CREATE INDEX index_comments_on_user_id ON comments USING btree (user_id);
 
 
 --
+-- Name: index_comments_on_workflow_state; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_comments_on_workflow_state ON comments USING btree (workflow_state);
+
+
+--
 -- Name: index_friendly_id_slugs_on_slug_and_sluggable_type; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -1270,4 +1278,6 @@ INSERT INTO schema_migrations (version) VALUES ('20140814083303');
 INSERT INTO schema_migrations (version) VALUES ('20140814103434');
 
 INSERT INTO schema_migrations (version) VALUES ('20140814104713');
+
+INSERT INTO schema_migrations (version) VALUES ('20140826095352');
 

--- a/features/step_definitions/user_submits_comment.rb
+++ b/features/step_definitions/user_submits_comment.rb
@@ -9,6 +9,16 @@ When(/^I fill out the comment form$/) do
   click_on 'Post comment'
 end
 
+When(/^I fill out the comment form with "(.*?)"$/) do |arg1|
+  @comment_body = arg1
+  fill_in 'comment_body', with: @comment_body
+  click_on 'Post comment'
+end
+
 Then(/^I should see my comment at the top of the list$/) do
   expect(page).to have_content(@comment_body)
+end
+
+Then(/^I should not see my comment in the list$/) do
+  expect(page).to_not have_content(@comment_body)
 end

--- a/features/user_submits_comment.feature
+++ b/features/user_submits_comment.feature
@@ -8,3 +8,10 @@ Feature: User submits comment
     When I visit question page
     And I fill out the comment form
     Then I should see my comment at the top of the list
+
+  Scenario: User posts profane comment
+    Given I am logged in
+    When I visit question page
+    And I fill out the comment form with "Yo! What the fuck? This shit craay!!!"
+    Then I should not see my comment in the list
+    And I should see "Thanks! Your comment will be reviewed"

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -4,4 +4,20 @@ describe Comment, :type => :model do
   it { is_expected.to belong_to(:question) }
   it { is_expected.to belong_to(:user) }
   it { is_expected.to validate_presence_of(:body) }
+
+  describe "profanity filter" do
+    let(:dirty_comment) { FactoryGirl.create(:comment,
+                    body: "Yo! What the fuck? This shit is krayyy!!") }
+    let(:clean_comment) { FactoryGirl.create(:comment,
+                    body: "I like rainbows. Do you? Meowww!!") }
+
+    it "is marked as awaiting_review if it has profane words" do
+      expect(dirty_comment).to be_awaiting_review
+    end
+
+    it 'is marked as default if no profane words' do
+      expect(clean_comment).to be_default
+      expect(clean_comment).not_to be_awaiting_review
+    end
+  end
 end


### PR DESCRIPTION
- Create ProfanityFilter concern.
- Add filter to comment.
- Added scope to comments in admin.

@jonlemmon Only noticeable omission is scoping the counter cache, so the numbers might look a bit off. Can look into that later.
