### PR TITLE
Fix issue with admin interface when assigning a rep to a party

### DIFF
--- a/app/admin/reps.rb
+++ b/app/admin/reps.rb
@@ -2,6 +2,8 @@ ActiveAdmin.register Rep do
   scope :all
   scope :unassigned
 
+  permit_params :user_id, :party_id
+  
   index do
     column :id
     column :user_name


### PR DESCRIPTION
This issue prevented the assignment of a rep to party when using the ActiveAdmin interface.